### PR TITLE
Allow bulk edit interval scheduler to use end-hour slot

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -7431,6 +7431,7 @@ async def prompt_bulk_edit_settings(query, user, posts, scope_name):
 *⚡ How it works:*
 • Auto intervals: Posts spread evenly across time range
 • Fixed intervals: Posts every X hours within range
+• End hour is inclusive (last post can be right at that time)
 • If no date specified, starts tomorrow
 • Times are in Kyiv timezone
 """

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -359,26 +359,22 @@ def calculate_evenly_distributed_schedule(start_hour: int, end_hour: int, num_po
     
     # If interval is specified, use it; otherwise auto-calculate
     if interval_hours and interval_hours > 0:
-        # Use fixed interval scheduling
-        posts_per_day = max(1, daily_window_hours // interval_hours + 1)
+        # Use fixed interval scheduling while allowing a slot exactly at end_hour
         current_date = start_date
         posts_scheduled = 0
-        
+        current_hour = start_hour
+
         while posts_scheduled < num_posts:
-            posts_today = min(num_posts - posts_scheduled, posts_per_day)
-            current_hour = start_hour
-            
-            for i in range(posts_today):
-                if current_hour <= end_hour:
-                    schedule_time = current_date.replace(hour=current_hour, minute=0, second=0, microsecond=0)
-                    schedule_times.append(schedule_time)
-                    posts_scheduled += 1
-                    current_hour += interval_hours
-                else:
-                    break
-            
-            # Move to next day
-            current_date += timedelta(days=1)
+            if current_hour > end_hour:
+                # Reset to start of next day once we go past the end hour window
+                current_date += timedelta(days=1)
+                current_hour = start_hour
+                continue
+
+            schedule_time = current_date.replace(hour=current_hour, minute=0, second=0, microsecond=0)
+            schedule_times.append(schedule_time)
+            posts_scheduled += 1
+            current_hour += interval_hours
     else:
         # Auto-distribute evenly
         daily_window_minutes = daily_window_hours * 60


### PR DESCRIPTION
## Summary
- allow the bulk edit interval scheduler to place a post exactly at the configured end hour while still moving remaining slots to the next day
- update the bulk edit prompt copy to explain that the end hour is inclusive

## Testing
- `python - <<'PY'
from datetime import datetime
from bot.utils import calculate_evenly_distributed_schedule, get_kyiv_timezone
start_date = get_kyiv_timezone().localize(datetime(2025,10,7))
for count in (5,6,15):
    res = calculate_evenly_distributed_schedule(10,20,count,start_date,2)
    print('count', count)
    for dt in res:
        print(' ', dt)
    print('-'*20)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68e4327b8080832f94be45dcc9de331a